### PR TITLE
writing record metadata & 2 maintenance updates

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,6 @@
-(defproject com.velisco/tagged "0.5.0"
+(defproject com.velisco/tagged "0.6.0-SNAPSHOT"
   :description "Clojure library for printing and reading Records as EDN tagged literals"
   :url "http://github.com/miner/tagged"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]])
-
+  :dependencies [[org.clojure/clojure "1.12.0"]])

--- a/src/miner/tagged.clj
+++ b/src/miner/tagged.clj
@@ -10,7 +10,7 @@
 ;; clojure.lang.TaggedLiteral and the `tagged-literal` function.
 
 ;; DEPRECATED
-(defrecord TaggedValue [tag value]
+(defrecord ^:deprecated TaggedValue [tag value]
   Object 
   (toString [x] (pr-str x)))
 

--- a/src/miner/tagged.clj
+++ b/src/miner/tagged.clj
@@ -126,6 +126,12 @@ the tag-readers in order returning the first truthy result (or nil if none)."
      (defmethod print-method my.ns.MyRecord [this w]
        (miner.tagged/pr-tagged-record-on this w))"
   [this ^java.io.Writer w]
+  (when (and *print-meta*
+             (instance? clojure.lang.IMeta this)
+             (seq (meta this)))
+    (.write w "^")
+    (print-method (meta this) w)
+    (.write w " "))
   (.write w "#")
   (.write w ^String (tag-string (class this)))
   (.write w " ")


### PR DESCRIPTION
This merge request pull together 1 new feature with 2 maintenance changes.

## Writing metadata

`defrecord`'s implement `clojure.lang.IMeta` and may have metadata added to their instances. An edn-compliant serializer must respect the `*print-meta*` dynamic var, and when true, print out the record's meta-data. 

This MR is primarily about adding this to `pr-tagged-record-on`.

## Clojure 1.12.0

Updated in `project.clj`

## `^:deprecated`

The `(defrecord TaggedValue ...)` was previously marked with a `;; DEPRECATED` comment. This MR adds the `:deprecated` meta-data to the `defrecord` declaration. Tooling have adopted support for this flag since the last update to the library.

## version-bump

In the `project.clj` file, the version has been bumped to `0.6.0-SNAPSHOT`. This is mostly a suggestion and can be removed from the PR on request.
